### PR TITLE
fix: correct email for Arlette Gelabert

### DIFF
--- a/baggers-rh.js
+++ b/baggers-rh.js
@@ -481,7 +481,7 @@ var data = {
         "Paris"
       ],
       "contacts": {
-        "mail": "agelabert@formenscène.com"
+        "mail": "agelabert@formenscene.com"
       }
     },
     {


### PR DESCRIPTION
`è` is not considered as valid in an email address by the email service.