### PR TITLE
fix: remove mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,0 @@
-pull_request_rules:
-  - name: automatic merge on positive review
-    conditions:
-      - "#approved-reviews-by>=1"
-    actions:
-      merge:
-        method: merge


### PR DESCRIPTION
When PR are merged by mergify, the Github Pages are not updated, cf. https://github.com/brownbaglunch/bblfr_data/issues/419#issuecomment-564640639